### PR TITLE
ci(renovate): enable platformAutomerge for native GitHub auto-merge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   ],
   "labels": ["dependencies"],
   "rangeStrategy": "pin",
+  "platformAutomerge": true,
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Enable `platformAutomerge` in Renovate config so it uses GitHub's native auto-merge instead of branch-based automerge. This ensures PRs go through required status checks (Notify PR) before merging.

## Changes

- Add `"platformAutomerge": true` to `.github/renovate.json`

## Test plan

- [x] JSON is valid
- [ ] Next Renovate PR should show "auto-merge" enabled via GitHub native mechanism

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated for changes
- [x] Documentation updated if needed