### PR TITLE
fix(lint): clear goconst/dupl findings and adopt shared renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,53 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "docker:enableMajor",
-    ":separateMajorReleases",
-    ":prHourlyLimitNone",
-    ":prConcurrentLimitNone"
-  ],
-  "labels": ["dependencies"],
-  "rangeStrategy": "pin",
-  "platformAutomerge": true,
-  "automergeStrategy": "squash",
-  "postUpdateOptions": ["gomodTidy"],
-  "packageRules": [
-    {
-      "description": "Group all Go module updates",
-      "matchManagers": ["gomod"],
-      "groupName": "go modules",
-      "groupSlug": "go-modules"
-    },
-    {
-      "description": "Group all GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "github actions",
-      "groupSlug": "github-actions"
-    },
-    {
-      "description": "Automerge all Go module updates including major",
-      "matchManagers": ["gomod"],
-      "automerge": true
-    },
-    {
-      "description": "Automerge all GitHub Actions updates including major",
-      "matchManagers": ["github-actions"],
-      "automerge": true
-    },
-    {
-      "description": "Pin and automerge Go version in Containerfile",
-      "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["docker.io/library/golang"],
-      "versioning": "docker",
-      "automerge": true
-    },
-    {
-      "description": "Bump Go version in go.mod to latest minor",
-      "matchManagers": ["gomod"],
-      "matchDepNames": ["go"],
-      "matchDepTypes": ["golang"],
-      "rangeStrategy": "bump"
-    }
+    "github>lexfrei/renovate-config",
+    "docker:enableMajor"
   ]
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,6 @@ jobs:
           go-version-file: go.mod
 
       - uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
 
   test:
     name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
 
   test:
     name: Test

--- a/cmd/mcp-transmission/main_test.go
+++ b/cmd/mcp-transmission/main_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// testServerName and testVersion are placeholder MCP server identity values
+// shared across the server tests.
+const (
+	testServerName = "test"
+	testVersion    = "0.0.0"
+)
+
 func TestNewServerOptions(t *testing.T) {
 	opts := newServerOptions()
 
@@ -29,7 +36,7 @@ func TestNewServerOptions(t *testing.T) {
 
 func TestRegisterTools(t *testing.T) {
 	server := mcp.NewServer(
-		&mcp.Implementation{Name: "test", Version: "0.0.0"},
+		&mcp.Implementation{Name: testServerName, Version: testVersion},
 		nil,
 	)
 
@@ -50,7 +57,7 @@ func TestRunHTTPServer_PortInUse(t *testing.T) {
 	addr := listener.Addr().String()
 
 	server := mcp.NewServer(
-		&mcp.Implementation{Name: "test", Version: "0.0.0"},
+		&mcp.Implementation{Name: testServerName, Version: testVersion},
 		nil,
 	)
 
@@ -102,7 +109,7 @@ func TestRunHTTPServer_GracefulShutdown(t *testing.T) {
 	listener.Close()
 
 	server := mcp.NewServer(
-		&mcp.Implementation{Name: "test", Version: "0.0.0"},
+		&mcp.Implementation{Name: testServerName, Version: testVersion},
 		nil,
 	)
 

--- a/internal/tools/format.go
+++ b/internal/tools/format.go
@@ -9,12 +9,15 @@ const (
 	bytesPerTB = bytesPerGB * 1024
 
 	percentMultiplier = 100
+
+	// statusUnknown is returned when a value cannot be formatted meaningfully.
+	statusUnknown = "unknown"
 )
 
 // formatBytes formats bytes into human-readable form.
 func formatBytes(bytes int64) string {
 	if bytes < 0 {
-		return "unknown"
+		return statusUnknown
 	}
 
 	switch {

--- a/internal/tools/format_test.go
+++ b/internal/tools/format_test.go
@@ -14,8 +14,8 @@ func TestFormatBytes_Units(t *testing.T) {
 		{"megabytes", 1572864, "1.50 MB"},
 		{"gigabytes", 1610612736, "1.50 GB"},
 		{"terabytes", 1649267441664, "1.50 TB"},
-		{"negative", -1, "unknown"},
-		{"large negative", -1099511627776, "unknown"},
+		{"negative", -1, statusUnknown},
+		{"large negative", -1099511627776, statusUnknown},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/free_space_test.go
+++ b/internal/tools/free_space_test.go
@@ -21,13 +21,13 @@ func TestFreeSpaceTool_Definition(t *testing.T) {
 func TestFreeSpaceHandler_Success(t *testing.T) {
 	client := newMockClient()
 	client.freeSpaceResult = &transmission.FreeSpace{
-		Path:      "/downloads",
+		Path:      testDownloadDir,
 		SizeBytes: 107374182400,
 	}
 
 	handler := tools.NewFreeSpaceHandler(client)
 
-	params := tools.FreeSpaceParams{Path: "/downloads"}
+	params := tools.FreeSpaceParams{Path: testDownloadDir}
 
 	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
 	if err != nil {
@@ -38,8 +38,8 @@ func TestFreeSpaceHandler_Success(t *testing.T) {
 		t.Error("expected success")
 	}
 
-	if output.Path != "/downloads" {
-		t.Errorf("expected path /downloads, got %s", output.Path)
+	if output.Path != testDownloadDir {
+		t.Errorf("expected path %s, got %s", testDownloadDir, output.Path)
 	}
 }
 
@@ -61,7 +61,7 @@ func TestFreeSpaceHandler_NilResponse(t *testing.T) {
 
 	handler := tools.NewFreeSpaceHandler(client)
 
-	params := tools.FreeSpaceParams{Path: "/downloads"}
+	params := tools.FreeSpaceParams{Path: testDownloadDir}
 
 	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
 	if err != nil {

--- a/internal/tools/id_action.go
+++ b/internal/tools/id_action.go
@@ -1,0 +1,53 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// idsResult is the common output shape for tools that act on a list of
+// torrent IDs and report back a single human-readable message.
+type idsResult struct {
+	Message string `json:"message"`
+}
+
+// idsAction performs an action against the Transmission RPC API for a set of
+// torrent IDs.
+type idsAction func(ctx context.Context, ids []int64) error
+
+// idsParams is implemented by parameter structs that carry a list of torrent
+// IDs, allowing a single generic handler to validate and forward them.
+type idsParams interface {
+	torrentIDs() []int64
+}
+
+// newIDsActionHandler builds an MCP handler for tools whose only behaviour is
+// to validate a non-empty list of torrent IDs, invoke a single action against
+// the client, and return a formatted success message. The errMsg is used to
+// wrap any transport failure, and successMsg is the verb reported on success.
+func newIDsActionHandler[P idsParams](
+	action idsAction,
+	errMsg string,
+	successMsg string,
+) mcp.ToolHandlerFor[P, idsResult] {
+	return func(
+		ctx context.Context,
+		_ *mcp.CallToolRequest,
+		params P,
+	) (*mcp.CallToolResult, idsResult, error) {
+		ids := params.torrentIDs()
+		if len(ids) == 0 {
+			return &mcp.CallToolResult{IsError: true}, idsResult{},
+				validationErr(ErrIDsRequired)
+		}
+
+		err := action(ctx, ids)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, idsResult{},
+				transmissionErr(errMsg, err)
+		}
+
+		return nil, idsResult{Message: formatActionMessage(successMsg, ids)}, nil
+	}
+}

--- a/internal/tools/mock_test.go
+++ b/internal/tools/mock_test.go
@@ -53,10 +53,14 @@ func (m *mockClient) TorrentStop(_ context.Context, _ []int64) error {
 }
 
 func (m *mockClient) TorrentVerify(_ context.Context, _ []int64) error {
+	m.lastMethod = "TorrentVerify"
+
 	return m.err
 }
 
 func (m *mockClient) TorrentReannounce(_ context.Context, _ []int64) error {
+	m.lastMethod = "TorrentReannounce"
+
 	return m.err
 }
 

--- a/internal/tools/queue_test.go
+++ b/internal/tools/queue_test.go
@@ -21,7 +21,7 @@ func TestQueueMoveHandler_Top(t *testing.T) {
 	client := newMockClient()
 	handler := tools.NewQueueMoveHandler(client)
 
-	params := tools.QueueMoveParams{IDs: []int64{1}, Action: "top"}
+	params := tools.QueueMoveParams{IDs: []int64{1}, Action: testQueueTop}
 
 	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
 	if err != nil {
@@ -34,7 +34,7 @@ func TestQueueMoveHandler_Top(t *testing.T) {
 }
 
 func TestQueueMoveHandler_AllActions(t *testing.T) {
-	actions := []string{"top", "up", "down", "bottom"}
+	actions := []string{testQueueTop, "up", "down", "bottom"}
 
 	for _, action := range actions {
 		t.Run(action, func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestQueueMoveHandler_TransmissionError(t *testing.T) {
 
 	handler := tools.NewQueueMoveHandler(client)
 
-	params := tools.QueueMoveParams{IDs: []int64{1}, Action: "top"}
+	params := tools.QueueMoveParams{IDs: []int64{1}, Action: testQueueTop}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
 	if !errors.Is(err, tools.ErrTransmission) {
@@ -89,7 +89,7 @@ func TestQueueMoveHandler_MissingIDs(t *testing.T) {
 	client := newMockClient()
 	handler := tools.NewQueueMoveHandler(client)
 
-	params := tools.QueueMoveParams{Action: "top"}
+	params := tools.QueueMoveParams{Action: testQueueTop}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
 	if !errors.Is(err, tools.ErrValidation) {

--- a/internal/tools/session_get_test.go
+++ b/internal/tools/session_get_test.go
@@ -20,7 +20,7 @@ func TestSessionGetTool_Definition(t *testing.T) {
 func TestSessionGetHandler_Success(t *testing.T) {
 	client := newMockClient()
 	version := "4.0.0"
-	downloadDir := "/downloads"
+	downloadDir := testDownloadDir
 
 	client.sessionResult = &transmission.Session{
 		Version:     &version,

--- a/internal/tools/session_set_test.go
+++ b/internal/tools/session_set_test.go
@@ -103,7 +103,7 @@ func TestSessionSetHandler_RelativeDownloadDir(t *testing.T) {
 	client := newMockClient()
 	handler := tools.NewSessionSetHandler(client)
 
-	rel := "relative/path"
+	rel := testRelativePath
 	params := tools.SessionSetParams{
 		DownloadDir: &rel,
 	}

--- a/internal/tools/testconst_test.go
+++ b/internal/tools/testconst_test.go
@@ -1,0 +1,12 @@
+package tools_test
+
+// Shared string fixtures reused across the tools test suite. Hoisted into a
+// single place so the same literal is not repeated in multiple test files.
+const (
+	testDownloadDir  = "/downloads"
+	testRelativePath = "relative/path"
+	testTorrentName  = "test-torrent"
+	testMagnetURI    = "magnet:?xt=urn:btih:abc123"
+	testQueueTop     = "top"
+	testActionAccept = "accept"
+)

--- a/internal/tools/torrent_add_test.go
+++ b/internal/tools/torrent_add_test.go
@@ -23,7 +23,7 @@ func TestTorrentAddHandler_Success(t *testing.T) {
 	client.torrentAddResult = &transmission.TorrentAddResult{
 		TorrentAdded: &transmission.TorrentAddedInfo{
 			ID:         1,
-			Name:       "test-torrent",
+			Name:       testTorrentName,
 			HashString: "abc123",
 		},
 	}
@@ -31,7 +31,7 @@ func TestTorrentAddHandler_Success(t *testing.T) {
 	handler := tools.NewTorrentAddHandler(client)
 
 	params := tools.TorrentAddParams{
-		Filename: "magnet:?xt=urn:btih:abc123",
+		Filename: testMagnetURI,
 	}
 
 	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -57,7 +57,7 @@ func TestTorrentAddHandler_Duplicate(t *testing.T) {
 	client.torrentAddResult = &transmission.TorrentAddResult{
 		TorrentDuplicate: &transmission.TorrentAddedInfo{
 			ID:         1,
-			Name:       "test-torrent",
+			Name:       testTorrentName,
 			HashString: "abc123",
 		},
 	}
@@ -65,7 +65,7 @@ func TestTorrentAddHandler_Duplicate(t *testing.T) {
 	handler := tools.NewTorrentAddHandler(client)
 
 	params := tools.TorrentAddParams{
-		Filename: "magnet:?xt=urn:btih:abc123",
+		Filename: testMagnetURI,
 	}
 
 	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -89,7 +89,7 @@ func TestTorrentAddHandler_NilResponse(t *testing.T) {
 	handler := tools.NewTorrentAddHandler(client)
 
 	params := tools.TorrentAddParams{
-		Filename: "magnet:?xt=urn:btih:abc123",
+		Filename: testMagnetURI,
 	}
 
 	_, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -109,7 +109,7 @@ func TestTorrentAddHandler_BothNilResult(t *testing.T) {
 	handler := tools.NewTorrentAddHandler(client)
 
 	params := tools.TorrentAddParams{
-		Filename: "magnet:?xt=urn:btih:abc123",
+		Filename: testMagnetURI,
 	}
 
 	_, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -129,7 +129,7 @@ func TestTorrentAddHandler_TransmissionError(t *testing.T) {
 	handler := tools.NewTorrentAddHandler(client)
 
 	params := tools.TorrentAddParams{
-		Filename: "magnet:?xt=urn:btih:abc123",
+		Filename: testMagnetURI,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -157,7 +157,7 @@ func TestTorrentAddHandler_ConflictingParams(t *testing.T) {
 	handler := tools.NewTorrentAddHandler(client)
 
 	params := tools.TorrentAddParams{
-		Filename: "magnet:?xt=urn:btih:abc123",
+		Filename: testMagnetURI,
 		Metainfo: "base64data",
 	}
 
@@ -180,8 +180,8 @@ func TestTorrentAddHandler_RelativeDownloadDir(t *testing.T) {
 	handler := tools.NewTorrentAddHandler(client)
 
 	params := tools.TorrentAddParams{
-		Filename:    "magnet:?xt=urn:btih:abc123",
-		DownloadDir: "relative/path",
+		Filename:    testMagnetURI,
+		DownloadDir: testRelativePath,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)

--- a/internal/tools/torrent_details_test.go
+++ b/internal/tools/torrent_details_test.go
@@ -20,7 +20,7 @@ func TestTorrentDetailsTool_Definition(t *testing.T) {
 
 func TestTorrentDetailsHandler_Success(t *testing.T) {
 	client := newMockClient()
-	name := "test-torrent"
+	name := testTorrentName
 	id := int64(1)
 	status := transmission.TorrentStatusSeed
 

--- a/internal/tools/torrent_list_test.go
+++ b/internal/tools/torrent_list_test.go
@@ -24,7 +24,7 @@ func TestTorrentListTool_Definition(t *testing.T) {
 func TestTorrentListHandler_Success(t *testing.T) {
 	client := newMockClient()
 	status := transmission.TorrentStatusSeed
-	name := "test-torrent"
+	name := testTorrentName
 	id := int64(1)
 	pct := 1.0
 

--- a/internal/tools/torrent_move_test.go
+++ b/internal/tools/torrent_move_test.go
@@ -84,7 +84,7 @@ func TestTorrentMoveHandler_RelativePath(t *testing.T) {
 
 	params := tools.TorrentMoveParams{
 		IDs:      []int64{1},
-		Location: "relative/path",
+		Location: testRelativePath,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)

--- a/internal/tools/torrent_reannounce.go
+++ b/internal/tools/torrent_reannounce.go
@@ -1,8 +1,6 @@
 package tools
 
 import (
-	"context"
-
 	"github.com/lexfrei/go-transmission/api/transmission"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -12,35 +10,17 @@ type TorrentReannounceParams struct {
 	IDs []int64 `json:"ids" jsonschema:"Torrent IDs to reannounce"`
 }
 
-// TorrentReannounceResult is the output of the transmission_torrent_reannounce tool.
-type TorrentReannounceResult struct {
-	Message string `json:"message"`
-}
+func (p TorrentReannounceParams) torrentIDs() []int64 { return p.IDs }
 
 // NewTorrentReannounceHandler creates a handler for the transmission_torrent_reannounce tool.
 func NewTorrentReannounceHandler(
 	client transmission.Client,
-) mcp.ToolHandlerFor[TorrentReannounceParams, TorrentReannounceResult] {
-	return func(
-		ctx context.Context,
-		_ *mcp.CallToolRequest,
-		params TorrentReannounceParams,
-	) (*mcp.CallToolResult, TorrentReannounceResult, error) {
-		if len(params.IDs) == 0 {
-			return &mcp.CallToolResult{IsError: true}, TorrentReannounceResult{},
-				validationErr(ErrIDsRequired)
-		}
-
-		announceErr := client.TorrentReannounce(ctx, params.IDs)
-		if announceErr != nil {
-			return &mcp.CallToolResult{IsError: true}, TorrentReannounceResult{},
-				transmissionErr("failed to reannounce torrents", announceErr)
-		}
-
-		return nil, TorrentReannounceResult{
-			Message: formatActionMessage("Reannounced", params.IDs),
-		}, nil
-	}
+) mcp.ToolHandlerFor[TorrentReannounceParams, idsResult] {
+	return newIDsActionHandler[TorrentReannounceParams](
+		client.TorrentReannounce,
+		"failed to reannounce torrents",
+		"Reannounced",
+	)
 }
 
 // TorrentReannounceTool returns the MCP tool definition for transmission_torrent_reannounce.

--- a/internal/tools/torrent_reannounce_test.go
+++ b/internal/tools/torrent_reannounce_test.go
@@ -24,13 +24,21 @@ func TestTorrentReannounceHandler_Success(t *testing.T) {
 
 	params := tools.TorrentReannounceParams{IDs: []int64{1}}
 
-	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
+	result, out, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
 	if err != nil {
 		t.Fatalf("handler failed: %v", err)
 	}
 
 	if result != nil && result.IsError {
 		t.Error("expected success")
+	}
+
+	if out.Message != "Reannounced 1 torrent(s)" {
+		t.Errorf("expected message %q, got %q", "Reannounced 1 torrent(s)", out.Message)
+	}
+
+	if client.LastMethod() != "TorrentReannounce" {
+		t.Errorf("expected method TorrentReannounce, got %s", client.LastMethod())
 	}
 }
 

--- a/internal/tools/torrent_remove_test.go
+++ b/internal/tools/torrent_remove_test.go
@@ -53,7 +53,7 @@ func TestTorrentRemoveHandler_MissingIDs(t *testing.T) {
 func TestTorrentRemoveHandler_DeleteLocalData_ElicitAccept(t *testing.T) {
 	client := newMockClient()
 	elicitor := &mockElicitor{
-		result: &mcp.ElicitResult{Action: "accept"},
+		result: &mcp.ElicitResult{Action: testActionAccept},
 	}
 	handler := tools.NewTorrentRemoveHandlerWithElicitor(client, elicitor)
 
@@ -195,7 +195,7 @@ func TestTorrentRemoveHandler_DeleteLocalData_ElicitNilResult(t *testing.T) {
 func TestTorrentRemoveHandler_NoDeleteLocalData_SkipsElicitation(t *testing.T) {
 	client := newMockClient()
 	elicitor := &mockElicitor{
-		result: &mcp.ElicitResult{Action: "accept"},
+		result: &mcp.ElicitResult{Action: testActionAccept},
 	}
 	handler := tools.NewTorrentRemoveHandlerWithElicitor(client, elicitor)
 
@@ -271,7 +271,7 @@ func TestTorrentRemoveHandler_DeleteLocalData_NilRequest(t *testing.T) {
 func TestTorrentRemoveHandler_DeleteWithAccept_TransmissionError(t *testing.T) {
 	client := newMockClient()
 	client.err = errMock
-	elicitor := &mockElicitor{result: &mcp.ElicitResult{Action: "accept"}}
+	elicitor := &mockElicitor{result: &mcp.ElicitResult{Action: testActionAccept}}
 	handler := tools.NewTorrentRemoveHandlerWithElicitor(client, elicitor)
 
 	params := tools.TorrentRemoveParams{

--- a/internal/tools/torrent_stop.go
+++ b/internal/tools/torrent_stop.go
@@ -1,8 +1,6 @@
 package tools
 
 import (
-	"context"
-
 	"github.com/lexfrei/go-transmission/api/transmission"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -12,33 +10,15 @@ type TorrentStopParams struct {
 	IDs []int64 `json:"ids" jsonschema:"Torrent IDs to stop"`
 }
 
-// TorrentStopResult is the output of the transmission_torrent_stop tool.
-type TorrentStopResult struct {
-	Message string `json:"message"`
-}
+func (p TorrentStopParams) torrentIDs() []int64 { return p.IDs }
 
 // NewTorrentStopHandler creates a handler for the transmission_torrent_stop tool.
-func NewTorrentStopHandler(client transmission.Client) mcp.ToolHandlerFor[TorrentStopParams, TorrentStopResult] {
-	return func(
-		ctx context.Context,
-		_ *mcp.CallToolRequest,
-		params TorrentStopParams,
-	) (*mcp.CallToolResult, TorrentStopResult, error) {
-		if len(params.IDs) == 0 {
-			return &mcp.CallToolResult{IsError: true}, TorrentStopResult{},
-				validationErr(ErrIDsRequired)
-		}
-
-		err := client.TorrentStop(ctx, params.IDs)
-		if err != nil {
-			return &mcp.CallToolResult{IsError: true}, TorrentStopResult{},
-				transmissionErr("failed to stop torrents", err)
-		}
-
-		return nil, TorrentStopResult{
-			Message: formatActionMessage("Stopped", params.IDs),
-		}, nil
-	}
+func NewTorrentStopHandler(client transmission.Client) mcp.ToolHandlerFor[TorrentStopParams, idsResult] {
+	return newIDsActionHandler[TorrentStopParams](
+		client.TorrentStop,
+		"failed to stop torrents",
+		"Stopped",
+	)
 }
 
 // TorrentStopTool returns the MCP tool definition for transmission_torrent_stop.

--- a/internal/tools/torrent_stop_test.go
+++ b/internal/tools/torrent_stop_test.go
@@ -24,13 +24,21 @@ func TestTorrentStopHandler_Success(t *testing.T) {
 
 	params := tools.TorrentStopParams{IDs: []int64{1}}
 
-	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
+	result, out, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
 	if err != nil {
 		t.Fatalf("handler failed: %v", err)
 	}
 
 	if result != nil && result.IsError {
 		t.Error("expected success")
+	}
+
+	if out.Message != "Stopped 1 torrent(s)" {
+		t.Errorf("expected message %q, got %q", "Stopped 1 torrent(s)", out.Message)
+	}
+
+	if client.LastMethod() != "TorrentStop" {
+		t.Errorf("expected method TorrentStop, got %s", client.LastMethod())
 	}
 }
 

--- a/internal/tools/torrent_verify.go
+++ b/internal/tools/torrent_verify.go
@@ -1,8 +1,6 @@
 package tools
 
 import (
-	"context"
-
 	"github.com/lexfrei/go-transmission/api/transmission"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -12,35 +10,17 @@ type TorrentVerifyParams struct {
 	IDs []int64 `json:"ids" jsonschema:"Torrent IDs to verify"`
 }
 
-// TorrentVerifyResult is the output of the transmission_torrent_verify tool.
-type TorrentVerifyResult struct {
-	Message string `json:"message"`
-}
+func (p TorrentVerifyParams) torrentIDs() []int64 { return p.IDs }
 
 // NewTorrentVerifyHandler creates a handler for the transmission_torrent_verify tool.
 func NewTorrentVerifyHandler(
 	client transmission.Client,
-) mcp.ToolHandlerFor[TorrentVerifyParams, TorrentVerifyResult] {
-	return func(
-		ctx context.Context,
-		_ *mcp.CallToolRequest,
-		params TorrentVerifyParams,
-	) (*mcp.CallToolResult, TorrentVerifyResult, error) {
-		if len(params.IDs) == 0 {
-			return &mcp.CallToolResult{IsError: true}, TorrentVerifyResult{},
-				validationErr(ErrIDsRequired)
-		}
-
-		verifyErr := client.TorrentVerify(ctx, params.IDs)
-		if verifyErr != nil {
-			return &mcp.CallToolResult{IsError: true}, TorrentVerifyResult{},
-				transmissionErr("failed to verify torrents", verifyErr)
-		}
-
-		return nil, TorrentVerifyResult{
-			Message: formatActionMessage("Queued verification for", params.IDs),
-		}, nil
-	}
+) mcp.ToolHandlerFor[TorrentVerifyParams, idsResult] {
+	return newIDsActionHandler[TorrentVerifyParams](
+		client.TorrentVerify,
+		"failed to verify torrents",
+		"Queued verification for",
+	)
 }
 
 // TorrentVerifyTool returns the MCP tool definition for transmission_torrent_verify.

--- a/internal/tools/torrent_verify_test.go
+++ b/internal/tools/torrent_verify_test.go
@@ -24,13 +24,21 @@ func TestTorrentVerifyHandler_Success(t *testing.T) {
 
 	params := tools.TorrentVerifyParams{IDs: []int64{1}}
 
-	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
+	result, out, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
 	if err != nil {
 		t.Fatalf("handler failed: %v", err)
 	}
 
 	if result != nil && result.IsError {
 		t.Error("expected success")
+	}
+
+	if out.Message != "Queued verification for 1 torrent(s)" {
+		t.Errorf("expected message %q, got %q", "Queued verification for 1 torrent(s)", out.Message)
+	}
+
+	if client.LastMethod() != "TorrentVerify" {
+		t.Errorf("expected method TorrentVerify, got %s", client.LastMethod())
 	}
 }
 


### PR DESCRIPTION
## Summary

The required lint checks were red on master because golangci-lint ran with `version: latest` (currently v2.12.2), which flagged pre-existing `goconst` and `dupl` findings. Those red checks blocked every open Renovate pull request. This branch fixes all findings, pins the linter to a Renovate-managed version, and migrates the Renovate configuration to the shared `github>lexfrei/renovate-config` preset.

## Changes

- Extract a generic `newIDsActionHandler` so the stop, verify, and reannounce tool handlers (previously byte-for-byte duplicates) delegate to one validated implementation, clearing the `dupl` findings.
- Hoist string literals that recurred three or more times to named constants (a `statusUnknown` constant in the format helper and shared fixture constants in the test suites), clearing the `goconst` findings.
- Pin golangci-lint to an explicit version annotated with a `# renovate:` comment in every workflow that runs the action, so a new linter release is reviewed through a pull request instead of silently turning the branch red.
- Replace the inline Renovate config with the shared `github>lexfrei/renovate-config` preset, keeping only `docker:enableMajor`, which the preset does not provide.

## Test plan

- [x] Unit tests pass (`go test -race -count=1 ./...`)
- [x] Linter passes (`golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` reports 0 issues with v2.12.2)
- [x] Manual testing completed (`go build ./...`, `go vet ./...`, `gofmt -l .` clean, Renovate config validated with `renovate-config-validator`)

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated for changes
- [ ] Documentation updated if needed
